### PR TITLE
refactor: Github Actions workflow

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -4,6 +4,7 @@ on:
 
 jobs:
   check-if-dist-changed:
+    name: Check if `dist/` is changed
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,4 +1,4 @@
-name: Check for updated dist files
+name: Pull Request
 on:
   pull_request:
 

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,0 +1,67 @@
+name: Check for updated dist files
+on:
+  pull_request:
+
+jobs:
+  check-if-dist-changed:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: dorny/paths-filter@v2
+        id: changes
+        with:
+          filters: |
+            dist:
+              - 'dist/**'
+      - uses: mshick/add-pr-comment@v1
+        if: steps.changes.outputs.dist == 'true'
+        with:
+          message: |
+            Hi 👋
+
+            Thank you for this contribution!
+            Due to security reasons, we only allow updating the `dist/**` files with our own workflows.
+          repo-token: ${{ secrets.BJERK_BOT_TOKEN }}
+          repo-token-user-login: bjerk-bot
+  install-and-build:
+    name: Install and Build GHA
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+      fail-fast: true
+    steps:
+      - uses: actions/checkout@v2
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+
+      - uses: actions/cache@v2
+        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+
+      - run: yarn install
+
+      - name: Cache dist files
+        id: dist-cache
+        uses: actions/cache@v2
+        with:
+          path: dist/
+          key: ${{ runner.os }}-build-${{ github.ref }}
+
+      - run: yarn build
+        if: steps.dist-cache.outputs.cache-hit != 'true'
+
+      - uses: dorny/paths-filter@v2
+        id: changes
+        with:
+          filters: |
+            dist:
+              - 'dist/**'
+
+      - run: echo "::warning::There are no changes to dist files"
+        if: steps.changes.outputs.dist != 'true'

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -20,5 +20,11 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-yarn-
 
-      - run: yarn install
-      - run: yarn build
+      - name: Install dependencies
+        run: yarn install
+
+      - name: Build GHA
+        run: yarn build
+
+      - name: Upload Code Coverage
+        run: npx codecov

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,0 +1,24 @@
+on:
+  push:
+    branches: [main]
+
+jobs:
+  install-and-build:
+    name: Install and Build GHA
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+
+      - uses: actions/cache@v2
+        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+
+      - run: yarn install
+      - run: yarn build

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -10,6 +10,5 @@ jobs:
       - uses: GoogleCloudPlatform/release-please-action@v2
         id: release
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.PRIVATE_GITHUB_TOKEN }}
           release-type: node
-          package-name: btools

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,15 @@
+on:
+  push:
+    branches:
+      - main
+name: release-please
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: GoogleCloudPlatform/release-please-action@v2
+        id: release
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          release-type: node
+          package-name: btools

--- a/.github/workflows/tag.yaml
+++ b/.github/workflows/tag.yaml
@@ -1,0 +1,13 @@
+on:
+  release:
+    types: [published, edited]
+jobs:
+  tag-major:
+    name: Push major-release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: Actions-R-Us/actions-tagger@latest
+        env:
+          GITHUB_TOKEN: '${{ github.token }}'
+        with:
+          publish_latest_tag: false

--- a/.github/workflows/update_dist.yml
+++ b/.github/workflows/update_dist.yml
@@ -1,0 +1,20 @@
+name: Update dist files
+on:
+  push:
+    branches:
+      - main
+      - master
+
+jobs:
+  update-dist:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: yarn install
+      - run: yarn build
+      - uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          file_pattern: dist/**
+          commit_message: 'chore(dist): Update dist [automated commit]'
+          commit_user_name: Bjerk Bot
+          commit_user_email: bjerk-bot@users.noreply.github.com

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.1.6",
   "description": "Export secrets from Vault into Github Actions",
   "engines": {
-    "node": ">= 12.13 <13"
+    "node": ">= 14.16"
   },
   "devDependencies": {
     "@octokit/fixtures": "^21.2.5",
@@ -65,7 +65,7 @@
     "uuid": "^8.3.1"
   },
   "volta": {
-    "node": "12.13.0",
+    "node": "14.16.0",
     "yarn": "1.22.10"
   }
 }


### PR DESCRIPTION
This workflow changes how the overall workflow for this repository is.

Most notably, the release process is automated with the use of [release-please](https://github.com/googleapis/release-please). Changes to `dist/` is no longer allowed in pull requests, as they will be updated automatically on every change (thanks @bjerk-bot).

In case you are unfamiliar with release-please, it might be difficult to understand how this works in practical terms. So let me explain! 👍 

1. Do feature work in branches per [GitHub flow](https://guides.github.com/introduction/flow/).

2. Create pull requests to the `main` branch to initiate discussion and review, squash merging when ready (title needs to be according to [conventional commit](https://www.conventionalcommits.org/))

* When a pull request is opened, either from a branch or a fork, GitHub Actions again runs the `pull_request` workflow, this time with the merge commit.

* On every commit to `main`, Github Actions runs the `release-please` workflow, which analyzes the commits. If there are commits that contain conventional commit (e.g. `feat:` or `fix:`), a release pull request is automatically created.

* When the release is created, GitHub Actions runs a `publish` workflow that pushes to the major version as well (e.g. `v1.2.3` -> `v1`).