### PR TITLE
feat: Add ability to set `branch` to always use same branch

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -21,8 +21,8 @@ inputs:
   base-path:
     description: Only add files in a spesific folder, e.g. .github/workflows
     required: false
-  branch-name:
-    description: Set branch name to use one branch for all updates.
+  branch:
+    description: Set branch to use one for all updates.
     required: false
 runs:
   using: 'node12'

--- a/action.yml
+++ b/action.yml
@@ -5,22 +5,25 @@ branding:
   icon: copy
   color: purple
 inputs:
-    github-token:
-        description: Github Token
-        default: ${{ github.token }}
-        required: true
-    files:
-        description: Files to import. e.g. templates/**
-        required: false
-    github-search:
-        description: Search for repositories instead of implictly set them (e.g. «org:bjerkio topic:infra»)
-        required: false
-    repos:
-        description: Repositories to push changes to
-        required: true
-    base-path:
-        description: Only add files in a spesific folder, e.g. .github/workflows
-        required: false
+  github-token:
+    description: Github Token
+    default: ${{ github.token }}
+    required: true
+  files:
+    description: Files to import. e.g. templates/**
+    required: false
+  github-search:
+    description: Search for repositories instead of implictly set them (e.g. «org:bjerkio topic:infra»)
+    required: false
+  repos:
+    description: Repositories to push changes to
+    required: true
+  base-path:
+    description: Only add files in a spesific folder, e.g. .github/workflows
+    required: false
+  branch-name:
+    description: Set branch name to use one branch for all updates.
+    required: false
 runs:
-    using: 'node12'
-    main: 'dist/index.js'
+  using: 'node12'
+  main: 'dist/index.js'

--- a/src/config.ts
+++ b/src/config.ts
@@ -90,7 +90,7 @@ export const makeConfig = async (
     repos: parseMultiInput(getInput('repos')),
     basePath: getInput('base-path'),
     githubSearch: getInput('github-search'),
-    branchName: getInput('branch-name'),
+    branchName: getInput('branch'),
   });
 
   if (!input.repos && getRepos && input.githubSearch) {

--- a/src/config.ts
+++ b/src/config.ts
@@ -69,6 +69,14 @@ export const GithubActionsConfig = Record({
    * Example: org:bjerkio topic:infrastructure
    */
   githubSearch: String.optional(),
+
+  /**
+   * Use one branch name for all updates.
+   *
+   * If the branch already exists, changes
+   * will be forcibly pushed.
+   */
+  branchName: String.optional(),
 });
 
 export type GithubActionsConfigType = Static<typeof GithubActionsConfig>;
@@ -82,6 +90,7 @@ export const makeConfig = async (
     repos: parseMultiInput(getInput('repos')),
     basePath: getInput('base-path'),
     githubSearch: getInput('github-search'),
+    branchName: getInput('branch-name'),
   });
 
   if (!input.repos && getRepos && input.githubSearch) {

--- a/src/git.ts
+++ b/src/git.ts
@@ -1,4 +1,3 @@
-import { debug } from '@actions/core';
 import * as exec from '@actions/exec';
 import * as github from '@actions/github';
 import { makeConfig } from './config';

--- a/src/git.ts
+++ b/src/git.ts
@@ -41,45 +41,11 @@ export async function cloneRepository(
   return [data, tmpDir];
 }
 
-export async function branchExists(
-  branch: string,
-  context: TemplateContext,
-): Promise<boolean> {
-  const { githubToken } = await makeConfig();
-  const {
-    github: { owner, name },
-  } = context;
-  const octokit = github.getOctokit(githubToken);
-  try {
-    const branchInfo = await octokit.rest.repos.getBranch({
-      repo: name,
-      owner: owner.login,
-      branch,
-    });
-    debug(`Found branch ${branchInfo}`);
-    return true;
-  } catch (e) {
-    if (e.message === 'Branch not found') {
-      return true;
-    }
-    throw new Error(`Failed to get branch: ${e.message}`);
-  }
-}
-
 export async function createBranch(
   repoDir: string,
   branchName: string,
 ): Promise<void> {
   await exec.exec('git checkout -b', [branchName], {
-    cwd: repoDir,
-  });
-}
-
-export async function checkoutBranch(
-  repoDir: string,
-  branchName: string,
-): Promise<void> {
-  await exec.exec('git checkout', [branchName], {
     cwd: repoDir,
   });
 }

--- a/src/git.ts
+++ b/src/git.ts
@@ -69,10 +69,17 @@ export async function branchExists(
 export async function createBranch(
   repoDir: string,
   branchName: string,
-  context: TemplateContext,
 ): Promise<void> {
-  const exists = await branchExists(branchName, context);
-  await exec.exec(exists ? `git checkout` : `git checkout -b`, [branchName], {
+  await exec.exec('git checkout -b', [branchName], {
+    cwd: repoDir,
+  });
+}
+
+export async function checkoutBranch(
+  repoDir: string,
+  branchName: string,
+): Promise<void> {
+  await exec.exec('git checkout', [branchName], {
     cwd: repoDir,
   });
 }
@@ -98,7 +105,9 @@ export async function applyChanges(
     cwd: repoDir,
   });
   await exec.exec(`git commit -m`, [message, '--no-verify'], { cwd: repoDir });
-  await exec.exec(`git push --force -u origin `, [branchName], { cwd: repoDir });
+  await exec.exec(`git push --force -u origin `, [branchName], {
+    cwd: repoDir,
+  });
 }
 
 export async function openPullRequest(

--- a/src/index.ts
+++ b/src/index.ts
@@ -55,7 +55,7 @@ export async function run(): Promise<void> {
           chalk.magenta(`Creating a new branch named ${branchName} in `),
       );
 
-      await createBranch(repoDir, branchName);
+      await createBranch(repoDir, branchName, context);
 
       core.info(
         chalk.bold(`${repo}: `) + chalk.magenta('Copying and generating files'),


### PR DESCRIPTION
This pull request adds the ability to set `branch`.

Branches are checked if they exist first, and if they do, it updates the branch.
If the branch exists, we overwrite the branch (`git --force -u origin <name of your branch>`).

This also opens up a question, whether we should [check if the branch exists and if its changed by others than the caller](https://github.com/bjerkio/kopier/issues/21).

### Example

```yaml
- uses: bjerkio/kopier@v1
  with:
    branch: automated-kopier
```